### PR TITLE
Fix results links, add delete option, and filter by client in version 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ For support and feature requests, please contact the plugin developer or submit 
 
 ## Changelog
 
+### Version 1.3
+- Fixed incorrect result links by normalizing and validating URLs before saving
+- Filtered out fake/suspicious domains from AI results
+- Added ability to delete individual monitoring results from the admin Results page (soft delete)
+- Results page now includes a client filter to view results per client
+- Bumped plugin version to 1.3
+
 ### Version 1.0.0
 - Initial release
 - Client profile management

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -172,6 +172,38 @@ jQuery(document).ready(function($) {
         window.location.href = 'admin.php?page=brm-results&client_id=' + clientId;
     };
 
+    // Delete a monitoring result
+    window.brmDeleteResult = function(resultId) {
+        if (!confirm('Delete this result?')) {
+            return;
+        }
+        var $button = jQuery('button[onclick*="brmDeleteResult(' + resultId + ')"]');
+        var originalText = $button.text();
+        $button.prop('disabled', true).text('Deleting...');
+
+        jQuery.post(brm_ajax.ajax_url, {
+            action: 'brm_delete_result',
+            result_id: resultId,
+            nonce: brm_ajax.nonce
+        }, function(response) {
+            if (response.success) {
+                showNotice('Result deleted successfully!', 'success');
+                // Remove the row from the table
+                var $row = jQuery('tr[data-result-id="' + resultId + '"]');
+                if ($row.length) {
+                    $row.fadeOut(200, function() { jQuery(this).remove(); });
+                }
+            } else {
+                showNotice('Error: ' + response.data, 'error');
+            }
+        }).fail(function(xhr, status, error) {
+            showNotice('Network error. Please try again.', 'error');
+            console.error('Delete Result Error:', xhr, status, error);
+        }).always(function() {
+            $button.prop('disabled', false).text(originalText);
+        });
+    };
+
     // Auto-refresh stats every 30 seconds
     if (typeof brm_ajax !== 'undefined' && $('.brm-stats-grid').length > 0) {
         setInterval(function() {

--- a/brand-reputation-monitor.php
+++ b/brand-reputation-monitor.php
@@ -3,7 +3,7 @@
  * Plugin Name: Brand Reputation Monitor
  * Plugin URI: https://www.kre8ivtech.com
  * Description: Monitor client brand reputation by tracking mentions, articles, news, and backlinks across the web using AI-powered analysis.
- * Version: 1.2
+ * Version: 1.3
  * Author: Kre8ivTech
  * Author URI: https://www.kre8ivtech.com
  * License: GPL v2 or later
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 // Define plugin constants
 define('BRM_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('BRM_PLUGIN_PATH', plugin_dir_path(__FILE__));
-define('BRM_VERSION', '1.2');
+define('BRM_VERSION', '1.3');
 
 // Include required files
 require_once BRM_PLUGIN_PATH . 'includes/class-brm-database.php';

--- a/includes/class-brm-database.php
+++ b/includes/class-brm-database.php
@@ -145,6 +145,19 @@ class BRM_Database {
             array('%d')
         );
     }
+
+    public static function delete_monitoring_result($id) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'brm_monitoring_results';
+
+        return $wpdb->update(
+            $table,
+            array('status' => 'deleted'),
+            array('id' => $id),
+            array('%s'),
+            array('%d')
+        );
+    }
     
     public static function save_monitoring_result($data) {
         global $wpdb;
@@ -174,6 +187,9 @@ class BRM_Database {
         $where = array();
         $where_values = array();
         
+        // Exclude deleted results by default
+        $where[] = "status != 'deleted'";
+        
         if ($client_id) {
             $where[] = "client_id = %d";
             $where_values[] = $client_id;
@@ -188,11 +204,7 @@ class BRM_Database {
         $sql = "SELECT * FROM $table $where_clause ORDER BY found_at DESC LIMIT %d";
         $where_values[] = $limit;
         
-        if (!empty($where_values)) {
-            return $wpdb->get_results($wpdb->prepare($sql, $where_values));
-        } else {
-            return $wpdb->get_results($wpdb->prepare($sql, $limit));
-        }
+        return $wpdb->get_results($wpdb->prepare($sql, $where_values));
     }
     
     public static function log_monitoring_action($client_id, $action, $details, $status = 'success') {


### PR DESCRIPTION
This pull request implements several key improvements for the Brand Reputation Monitor Plugin, now updated to version 1.3. Notable changes include:

- **Fixed incorrect result links** by normalizing and validating URLs prior to saving them.
- **Filtered out fake/suspicious domains** from the AI-generated results to enhance credibility.
- **Introduced the option to delete individual monitoring results** from the admin Results page, with a soft delete mechanism for increased data integrity.
- Added a **client filter** on the results page, allowing users to view results specific to each client.

These enhancements address the issues of fake results and incorrect links, and provide better user functionality by enabling result management.

---

> This pull request was co-created with Cosine Genie

Original Task: [client-scrub/mi96a38qpgvo](https://cosine.sh/kre8ivtech/client-scrub/task/mi96a38qpgvo)
Author: Jeremiah Castillo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Delete monitoring results from the Results page (soft-delete; hidden by default).
  * Filter results by client on the Results page.
  * Automatic URL normalization/validation to standardize links and reduce invalid/suspicious domains.
* Bug Fixes
  * Safer external links on the Results page.
* Documentation
  * README updated with a v1.3 changelog.
* Chores
  * Version bumped to 1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->