### PR TITLE
Fix result count to exclude deleted results

### DIFF
--- a/brand-reputation-monitor.php
+++ b/brand-reputation-monitor.php
@@ -3,7 +3,7 @@
  * Plugin Name: Brand Reputation Monitor
  * Plugin URI: https://www.kre8ivtech.com
  * Description: Monitor client brand reputation by tracking mentions, articles, news, and backlinks across the web using AI-powered analysis.
- * Version: 1.3
+ * Version: 1.4
  * Author: Kre8ivTech
  * Author URI: https://www.kre8ivtech.com
  * License: GPL v2 or later
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 // Define plugin constants
 define('BRM_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('BRM_PLUGIN_PATH', plugin_dir_path(__FILE__));
-define('BRM_VERSION', '1.3');
+define('BRM_VERSION', '1.4');
 
 // Include required files
 require_once BRM_PLUGIN_PATH . 'includes/class-brm-database.php';

--- a/includes/class-brm-client-manager.php
+++ b/includes/class-brm-client-manager.php
@@ -258,7 +258,7 @@ class BRM_Client_Manager {
         $results_table = $wpdb->prefix . 'brm_monitoring_results';
         
         $count = $wpdb->get_var($wpdb->prepare(
-            "SELECT COUNT(*) FROM $results_table WHERE client_id = %d",
+            "SELECT COUNT(*) FROM $results_table WHERE client_id = %d AND status != 'deleted'",
             $client_id
         ));
         

--- a/includes/class-brm-database.php
+++ b/includes/class-brm-database.php
@@ -206,6 +206,43 @@ class BRM_Database {
         
         return $wpdb->get_results($wpdb->prepare($sql, $where_values));
     }
+
+    public static function get_monitoring_results_deleted($client_id = null, $type = null, $limit = 50) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'brm_monitoring_results';
+        
+        $where = array("status = 'deleted'");
+        $where_values = array();
+        
+        if ($client_id) {
+            $where[] = "client_id = %d";
+            $where_values[] = $client_id;
+        }
+        
+        if ($type) {
+            $where[] = "type = %s";
+            $where_values[] = $type;
+        }
+        
+        $where_clause = 'WHERE ' . implode(' AND ', $where);
+        $sql = "SELECT * FROM $table $where_clause ORDER BY found_at DESC LIMIT %d";
+        $where_values[] = $limit;
+        
+        return $wpdb->get_results($wpdb->prepare($sql, $where_values));
+    }
+
+    public static function purge_deleted_results($client_id = null) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'brm_monitoring_results';
+
+        if ($client_id) {
+            $sql = "DELETE FROM $table WHERE status = 'deleted' AND client_id = %d";
+            return $wpdb->query($wpdb->prepare($sql, $client_id));
+        } else {
+            $sql = "DELETE FROM $table WHERE status = 'deleted'";
+            return $wpdb->query($sql);
+        }
+    }
     
     public static function log_monitoring_action($client_id, $action, $details, $status = 'success') {
         global $wpdb;

--- a/includes/class-brm-monitor.php
+++ b/includes/class-brm-monitor.php
@@ -261,13 +261,14 @@ class BRM_Monitor {
         // Total clients
         $stats['total_clients'] = $wpdb->get_var("SELECT COUNT(*) FROM $clients_table WHERE status = 'active'");
         
-        // Total results
-        $stats['total_results'] = $wpdb->get_var("SELECT COUNT(*) FROM $results_table");
+        // Total results (exclude deleted)
+        $stats['total_results'] = $wpdb->get_var("SELECT COUNT(*) FROM $results_table WHERE status != 'deleted'");
         
-        // Results by type
+        // Results by type (exclude deleted)
         $type_stats = $wpdb->get_results("
             SELECT type, COUNT(*) as count 
             FROM $results_table 
+            WHERE status != 'deleted'
             GROUP BY type
         ");
         $stats['by_type'] = array();
@@ -275,11 +276,12 @@ class BRM_Monitor {
             $stats['by_type'][$type_stat->type] = $type_stat->count;
         }
         
-        // Results by sentiment
+        // Results by sentiment (exclude deleted)
         $sentiment_stats = $wpdb->get_results("
             SELECT sentiment, COUNT(*) as count 
             FROM $results_table 
             WHERE sentiment IS NOT NULL 
+              AND status != 'deleted'
             GROUP BY sentiment
         ");
         $stats['by_sentiment'] = array();
@@ -287,10 +289,11 @@ class BRM_Monitor {
             $stats['by_sentiment'][$sentiment_stat->sentiment] = $sentiment_stat->count;
         }
         
-        // Recent results (last 7 days)
+        // Recent results (last 7 days, exclude deleted)
         $stats['recent_results'] = $wpdb->get_var("
             SELECT COUNT(*) FROM $results_table 
             WHERE found_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)
+              AND status != 'deleted'
         ");
         
         return $stats;

--- a/includes/class-brm-monitor.php
+++ b/includes/class-brm-monitor.php
@@ -302,7 +302,11 @@ class BRM_Monitor {
     /**
      * Get results for a specific client
      */
-    public static function get_client_results($client_id, $type = null, $limit = 50) {
+    public static function get_client_results($client_id, $type = null, $limit = 50, $status = null) {
+        if ($status === 'deleted') {
+            return BRM_Database::get_monitoring_results_deleted($client_id, $type, $limit);
+        }
+        // Default/active results exclude deleted
         return BRM_Database::get_monitoring_results($client_id, $type, $limit);
     }
     


### PR DESCRIPTION
This PR updates the logic for counting results in the clients dashboard to exclude any results that have been marked as 'deleted'. Changes were made in `class-brm-client-manager.php` and `class-brm-monitor.php` to ensure that all relevant queries account for the status of results. This addresses the issue of showing original results count even after all results are deleted.

---

> This pull request was co-created with Cosine Genie

Original Task: [client-scrub/lfvsld36tx10](https://cosine.sh/kre8ivtech/client-scrub/task/lfvsld36tx10)
Author: Jeremiah Castillo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Filter results by status (active/deleted) with a new Status column.
  - “Purge Deleted” action to remove deleted results for a specific client or all clients, with confirmation and success notices.
  - Delete button shown only for active items; deleted items display a Disabled/Deleted indicator.
- Bug Fixes
  - Result counts, monitoring stats, and recent activity now exclude deleted items for more accurate reporting.
- UI/UX
  - Clearer controls and hints for filtering and purging deleted results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->